### PR TITLE
refactor(Base64EncodedSignature): sign with/without querystring params

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,9 @@ RSpec/MessageSpies:
 RSpec/SubjectStub:
   Enabled: false
 
+RSpec/NestedGroups:
+  Enabled: false
+
 Gemspec/RequiredRubyVersion:
   Enabled: false
 

--- a/lib/comptacrypto/sdk/okx/base64_encoded_signature.rb
+++ b/lib/comptacrypto/sdk/okx/base64_encoded_signature.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "base64"
+require "openssl"
+
+module Comptacrypto
+  module Sdk
+    module Okx
+      # Signing Messages
+      #
+      # @see https://www.okx.com/docs/en/#signing-messages
+      # @see https://www.okx.com/docs-v5/en/#rest-api-authentication-signature
+      class Base64EncodedSignature
+        attr_reader :secret_key
+
+        def initialize(secret_key:)
+          @secret_key = secret_key
+        end
+
+        # @note Given the JS implementation example from the official doc,
+        #
+        #     var hash = CryptoJS.HmacSHA256("message", "secret");
+        #     // => { words: [ -1956689808, 697680217, -1940439631, -501717335, -1205480281, -1798215209, 101319520, 1469462027 ], sigBytes: 32 }
+        #
+        #     var hashInBase64 = CryptoJS.enc.Base64.stringify(hash);
+        #     // => 'i19IcCmVwVmMVz2x4hhmqbgl1KeU0WnXBgoDYFeWNgs='
+        #
+        #   the equivalent Ruby implementation should be:
+        #
+        #     hash = OpenSSL::HMAC.digest("SHA256", "secret", "message")
+        #     # => "\x8B_Hp)\x95\xC1Y\x8CW=\xB1\xE2\x18f\xA9\xB8%\xD4\xA7\x94\xD1i\xD7\x06\n\x03`W\x966\v"
+        #
+        #     Base64.strict_encode64(hash)
+        #     # => "i19IcCmVwVmMVz2x4hhmqbgl1KeU0WnXBgoDYFeWNgs="
+        def call(request_path:, ms_iso8601:)
+          message = "#{ms_iso8601}GET#{request_path}"
+          hash = ::OpenSSL::HMAC.digest("SHA256", secret_key, message)
+          ::Base64.strict_encode64(hash)
+        end
+      end
+    end
+  end
+end

--- a/lib/comptacrypto/sdk/okx/client.rb
+++ b/lib/comptacrypto/sdk/okx/client.rb
@@ -2,6 +2,7 @@
 
 require "faraday"
 require "time"
+require "uri"
 
 require_relative "base64_encoded_signature"
 

--- a/lib/comptacrypto/sdk/okx/client.rb
+++ b/lib/comptacrypto/sdk/okx/client.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require "base64"
 require "faraday"
-require "openssl"
 require "time"
+
+require_relative "base64_encoded_signature"
 
 module Comptacrypto
   module Sdk
@@ -60,30 +60,8 @@ module Comptacrypto
           ::Time.strptime(ms_ts_str, "%Q").utc.iso8601(3)
         end
 
-        # Signing Messages
-        #
-        # @note Given the JS implementation example from the official doc,
-        #
-        #     var hash = CryptoJS.HmacSHA256("message", "secret");
-        #     // => { words: [ -1956689808, 697680217, -1940439631, -501717335, -1205480281, -1798215209, 101319520, 1469462027 ], sigBytes: 32 }
-        #
-        #     var hashInBase64 = CryptoJS.enc.Base64.stringify(hash);
-        #     // => 'i19IcCmVwVmMVz2x4hhmqbgl1KeU0WnXBgoDYFeWNgs='
-        #
-        #   should match this Ruby implementation:
-        #
-        #     hash = OpenSSL::HMAC.digest("SHA256", "secret", "message")
-        #     # => "\x8B_Hp)\x95\xC1Y\x8CW=\xB1\xE2\x18f\xA9\xB8%\xD4\xA7\x94\xD1i\xD7\x06\n\x03`W\x966\v"
-        #
-        #     Base64.strict_encode64(hash)
-        #     # => "i19IcCmVwVmMVz2x4hhmqbgl1KeU0WnXBgoDYFeWNgs="
-        #
-        # @see https://www.okx.com/docs/en/#signing-messages
-        # @see https://www.okx.com/docs-v5/en/#rest-api-authentication-signature
         def sign(request_path:, ms_iso8601:)
-          message = "#{ms_iso8601}GET#{request_path}"
-          hash = ::OpenSSL::HMAC.digest("SHA256", secret_key, message)
-          ::Base64.strict_encode64(hash)
+          Base64EncodedSignature.new(secret_key:).call(request_path:, ms_iso8601:)
         end
       end
     end

--- a/spec/comptacrypto/sdk/okx/base64_encoded_signature_spec.rb
+++ b/spec/comptacrypto/sdk/okx/base64_encoded_signature_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe Comptacrypto::Sdk::Okx::Base64EncodedSignature do
+  subject(:encoder_klass) do
+    described_class
+  end
+
+  describe ".new" do
+    subject(:encoder_instance) do
+      encoder_klass.new(secret_key:)
+    end
+
+    context "when secret key is 'secret-foo'" do
+      let(:secret_key) do
+        "secret-foo"
+      end
+
+      describe "#call" do
+        subject(:encoded_value) do
+          encoder_instance.call(request_path:, ms_iso8601:)
+        end
+
+        let(:ms_iso8601) do
+          "2022-02-07T21:37:33.383Z"
+        end
+
+        context "without querystring params" do
+          let(:request_path) do
+            "/orders"
+          end
+
+          it "signs the message" do
+            expect(encoded_value).to eq "bI6DJV5K+G4laid4txciR/5p/pX4tjf39B5jIc6nFck="
+          end
+        end
+
+        context "with querystring params" do
+          let(:request_path) do
+            "/orders?before=2&limit=30"
+          end
+
+          it "signs the message" do
+            expect(encoded_value).to eq "olT7YgbofkVgIdeD5OxL6VHVfOMXRDHP+EjKCDGoFYU="
+          end
+        end
+      end
+    end
+
+    context "when secret key is 'secret-bar'" do
+      let(:secret_key) do
+        "secret-bar"
+      end
+
+      describe "#call" do
+        subject(:encoded_value) do
+          encoder_instance.call(request_path:, ms_iso8601:)
+        end
+
+        let(:ms_iso8601) do
+          "2022-02-07T21:37:33.383Z"
+        end
+
+        context "without querystring params" do
+          let(:request_path) do
+            "/orders"
+          end
+
+          it "signs the message" do
+            expect(encoded_value).to eq "gdct2bwMcqtQpGJTN7h3iGzkSs+nYHvtSV001gvZV34="
+          end
+        end
+
+        context "with querystring params" do
+          let(:request_path) do
+            "/orders?before=2&limit=30"
+          end
+
+          it "signs the message" do
+            expect(encoded_value).to eq "5gRqlGFBITlsVMK7Js2lWvS1z9UIZkJb07dtLlAL2Ig="
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/comptacrypto/sdk/okx/base64_encoded_signature_spec.rb
+++ b/spec/comptacrypto/sdk/okx/base64_encoded_signature_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Comptacrypto::Sdk::Okx::Base64EncodedSignature do
 
         context "without querystring params" do
           let(:request_path) do
-            "/orders"
+            URI("/orders")
           end
 
           it "signs the message" do
@@ -36,7 +36,7 @@ RSpec.describe Comptacrypto::Sdk::Okx::Base64EncodedSignature do
 
         context "with querystring params" do
           let(:request_path) do
-            "/orders?before=2&limit=30"
+            URI("/orders?before=2&limit=30")
           end
 
           it "signs the message" do
@@ -62,7 +62,7 @@ RSpec.describe Comptacrypto::Sdk::Okx::Base64EncodedSignature do
 
         context "without querystring params" do
           let(:request_path) do
-            "/orders"
+            URI("/orders")
           end
 
           it "signs the message" do
@@ -72,7 +72,7 @@ RSpec.describe Comptacrypto::Sdk::Okx::Base64EncodedSignature do
 
         context "with querystring params" do
           let(:request_path) do
-            "/orders?before=2&limit=30"
+            URI("/orders?before=2&limit=30")
           end
 
           it "signs the message" do

--- a/spec/comptacrypto/sdk/okx/client_spec.rb
+++ b/spec/comptacrypto/sdk/okx/client_spec.rb
@@ -54,22 +54,4 @@ RSpec.describe Comptacrypto::Sdk::Okx::Client do
       expect(client.withdrawal_history.body).to eq payload
     end
   end
-
-  describe "#sign" do
-    before do
-      allow(client).to receive(:secret_key).and_return("secret")
-    end
-
-    let(:request_path) do
-      "/foo/bar"
-    end
-
-    let(:ms_iso8601) do
-      "2022-02-07T21:37:33.383Z"
-    end
-
-    it "signs the message" do
-      expect(client.send(:sign, request_path:, ms_iso8601:)).to eq "XP6HICMaSSlQ4jC6a5e0m+NnTg3kmhrB9KvkcTZUhy0="
-    end
-  end
 end


### PR DESCRIPTION
# Que fait cette PR

Cette PR deplace la partie du code responsable de signer nos requetes dans une classe distincte.
