### PR TITLE
fix(ClientV5): invalid signature due to querystring

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ client_v5 = Comptacrypto::Sdk::Okx::ClientV5.new(
 )
 
 # Send a request to query server time
-client_v5.time # => #<Faraday::Response:0x00007f74e3a758f0>
-client_v5.time.body # => {"code"=>"0", "data"=>[{"ts"=>"1644499170774"}], "msg"=>""}
+client_v5.public_data_get_system_time # => #<Faraday::Response:0x00007f74e3a758f0>
+client_v5.public_data_get_system_time.body # => {"code"=>"0", "data"=>[{"ts"=>"1644499170774"}], "msg"=>""}
 ```
 
 ## Test

--- a/lib/comptacrypto/sdk/okx/client_v5.rb
+++ b/lib/comptacrypto/sdk/okx/client_v5.rb
@@ -1668,7 +1668,10 @@ module Comptacrypto
         def uri_query(**params)
           return if params.empty?
 
-          ::URI.encode_www_form(**params.transform_keys { |key| snake_case_to_lower_camel_case(key).to_sym })
+          params = params.transform_keys { |key| snake_case_to_lower_camel_case(key).to_sym }
+          params = params.sort.to_h
+
+          ::URI.encode_www_form(**params)
         end
       end
     end


### PR DESCRIPTION
# Pourquoi cette PR

Parfois, lorsque l'on utilise des parametres passes en querystring, l'exchange repond 401 :

> Invalid signature.

# Raison

Faraday trie les paramètres des URI passes en querystring. Du coup, lorsque nous en utilisons, si l'ordre n'est pas alphabetique, nous signons une chaine de caracteres du path qui n'est pas identique avec la chaine de caractere de ce meme path qui va etre effectivement utilisee pour consommer l'API. Cette anomalie entraine la generation d'une signature differente cote serveur, et l'erreur de la signature non valide.