### PR TITLE
add endpoint to get underlying

### DIFF
--- a/lib/comptacrypto/sdk/okx/client_v5.rb
+++ b/lib/comptacrypto/sdk/okx/client_v5.rb
@@ -119,6 +119,27 @@ module Comptacrypto
           get!("/api/v5/public/funding-rate-history", inst_id:, after:, before:, limit:)
         end
 
+        # Get underlying
+        #
+        # @note List of underlying for Instrument types : SWAP, FUTURES, OPTION
+        #
+        #   GET /api/v5/public/underlying
+        #
+        # @param inst_type [String]
+        #
+        # @see https://www.okx.com/docs-v5/en/#rest-api-public-data-get-underlying
+        def public_data_get_underlying(inst_type:)
+          instrument_types = %w[
+            SWAP
+            FUTURES
+            OPTION
+          ].freeze
+
+          raise ::ArgumentError unless instrument_types.include?(inst_type)
+
+          get!("/api/v5/public/underlying", inst_type:)
+        end
+
         # Private Endpoints
 
         # Get order details


### PR DESCRIPTION
Nous avons besoin de cet endpoint pour récupérer la liste des underlyings pour chaque `instrument_types`.

Nous allons pouvoir l'utiliser pour crawler [PublicDataGetDeliveryExerciseHistory](https://www.okx.com/docs-v5/en/#rest-api-public-data-get-delivery-exercise-history) qui a pour paramètre obligatoire `underlying`